### PR TITLE
Fix ValueError in oct2py calls

### DIFF
--- a/python/qa_autocorrelate.py
+++ b/python/qa_autocorrelate.py
@@ -51,11 +51,11 @@ class qa_autocorrelate (gr_unittest.TestCase):
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples'))		
 		print oc
-		[expected_S_x, data] = oc.doa_testbench_create('autocorrelate_test_input_gen', len_ss, overlap_size, num_inputs, FB)
+		expected_S_x, data = oc.doa_testbench_create('autocorrelate_test_input_gen', len_ss, overlap_size, num_inputs, FB, nout=2)
 		expected_S_x = tuple(expected_S_x)
 		expected_S_x = list(itertools.chain.from_iterable(expected_S_x))
 		# num of snapshots
-		n_ss = len(expected_S_x)/(num_inputs*num_inputs)
+		n_ss = len(expected_S_x)//(num_inputs*num_inputs)
 
 		##################################################
 		# Blocks & Connections
@@ -97,11 +97,11 @@ class qa_autocorrelate (gr_unittest.TestCase):
 		# Generate auto-correlation vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples'))		
-		[expected_S_x, data] = oc.doa_testbench_create('autocorrelate_test_input_gen', len_ss, overlap_size, num_inputs, FB)
+		expected_S_x, data = oc.doa_testbench_create('autocorrelate_test_input_gen', len_ss, overlap_size, num_inputs, FB, nout=2)
 		expected_S_x = tuple(expected_S_x)
 		expected_S_x = list(itertools.chain.from_iterable(expected_S_x))
 		# num of snapshots
-		n_ss = len(expected_S_x)/(num_inputs*num_inputs)
+		n_ss = len(expected_S_x)//(num_inputs*num_inputs)
 
 		##################################################
 		# Blocks & Connections
@@ -143,11 +143,11 @@ class qa_autocorrelate (gr_unittest.TestCase):
 		# Generate auto-correlation vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples'))		
-		[expected_S_x, data] = oc.doa_testbench_create('autocorrelate_test_input_gen', len_ss, overlap_size, num_inputs, FB)
+		expected_S_x, data = oc.doa_testbench_create('autocorrelate_test_input_gen', len_ss, overlap_size, num_inputs, FB, nout=2)
 		expected_S_x = tuple(expected_S_x)
 		expected_S_x = list(itertools.chain.from_iterable(expected_S_x))
 		# num of snapshots
-		n_ss = len(expected_S_x)/(num_inputs*num_inputs)
+		n_ss = len(expected_S_x)//(num_inputs*num_inputs)
 
 		##################################################
 		# Blocks & Connections

--- a/python/qa_calibrate_lin_array.py
+++ b/python/qa_calibrate_lin_array.py
@@ -56,7 +56,7 @@ class qa_calibrate_lin_array (gr_unittest.TestCase):
 		# Generate auto-correlation vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples'))
-		S_x, S_x_uncalibrated, ant_pert_vec = oc.doa_testbench_create('music_test_input_gen', len_ss, overlap_size, num_ant_ele, FB, 'linear', num_ant_ele, norm_spacing, PERTURB, pilot_doa)
+		S_x, S_x_uncalibrated, ant_pert_vec = oc.doa_testbench_create('music_test_input_gen', len_ss, overlap_size, num_ant_ele, FB, 'linear', num_ant_ele, norm_spacing, PERTURB, pilot_doa, nout=3)
 		S_x_uncalibrated = S_x_uncalibrated.flatten().tolist()
 		ant_pert_vec = list(itertools.chain.from_iterable(ant_pert_vec))
 
@@ -80,7 +80,7 @@ class qa_calibrate_lin_array (gr_unittest.TestCase):
 		ant_pert_vec_est = self.vec_sink.data()
 		ant_pert_vec_est = numpy.asarray(ant_pert_vec_est, 'F')
 		# num of snapshots
-		n_ss = len(ant_pert_vec_est)/num_ant_ele
+		n_ss = len(ant_pert_vec_est)//num_ant_ele
 
 		# check data
 		ant_ele_range = range(0, num_ant_ele)
@@ -111,7 +111,7 @@ class qa_calibrate_lin_array (gr_unittest.TestCase):
 		# Generate auto-correlation vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples'))
-		S_x, S_x_uncalibrated, ant_pert_vec = oc.doa_testbench_create('music_test_input_gen', len_ss, overlap_size, num_ant_ele, FB, 'linear', num_ant_ele, norm_spacing, PERTURB, pilot_doa)
+		S_x, S_x_uncalibrated, ant_pert_vec = oc.doa_testbench_create('music_test_input_gen', len_ss, overlap_size, num_ant_ele, FB, 'linear', num_ant_ele, norm_spacing, PERTURB, pilot_doa, nout=3)
 		S_x_uncalibrated = S_x_uncalibrated.flatten().tolist()
 		ant_pert_vec = list(itertools.chain.from_iterable(ant_pert_vec))
 
@@ -135,7 +135,7 @@ class qa_calibrate_lin_array (gr_unittest.TestCase):
 		ant_pert_vec_est = self.vec_sink.data()
 		ant_pert_vec_est = numpy.asarray(ant_pert_vec_est, 'F')
 		# num of snapshots
-		n_ss = len(ant_pert_vec_est)/num_ant_ele
+		n_ss = len(ant_pert_vec_est)//num_ant_ele
 
 		# check data
 		ant_ele_range = range(0, num_ant_ele)
@@ -166,7 +166,7 @@ class qa_calibrate_lin_array (gr_unittest.TestCase):
 		# Generate auto-correlation vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'examples'))
-		S_x, S_x_uncalibrated, ant_pert_vec = oc.doa_testbench_create('music_test_input_gen', len_ss, overlap_size, num_ant_ele, FB, 'linear', num_ant_ele, norm_spacing, PERTURB, pilot_doa)
+		S_x, S_x_uncalibrated, ant_pert_vec = oc.doa_testbench_create('music_test_input_gen', len_ss, overlap_size, num_ant_ele, FB, 'linear', num_ant_ele, norm_spacing, PERTURB, pilot_doa, nout=3)
 		S_x_uncalibrated = S_x_uncalibrated.flatten().tolist()
 		ant_pert_vec = list(itertools.chain.from_iterable(ant_pert_vec))
 
@@ -190,7 +190,7 @@ class qa_calibrate_lin_array (gr_unittest.TestCase):
 		ant_pert_vec_est = self.vec_sink.data()
 		ant_pert_vec_est = numpy.asarray(ant_pert_vec_est, 'F')
 		# num of snapshots
-		n_ss = len(ant_pert_vec_est)/num_ant_ele
+		n_ss = len(ant_pert_vec_est)//num_ant_ele
 
 		# check data
 		ant_ele_range = range(0, num_ant_ele)

--- a/python/qa_find_local_max.py
+++ b/python/qa_find_local_max.py
@@ -44,8 +44,9 @@ class qa_find_local_max (gr_unittest.TestCase):
 		# generate vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.dirname(__file__))	
-		data, expected_pks, expected_t_pks = oc.test001_findpeaks(self.num_max_vals, self.vector_len)
+		data, expected_pks, expected_t_pks = oc.test001_findpeaks(self.num_max_vals, self.vector_len, nout=3)
 		data = data.flatten().tolist()
+		expected_pks = expected_pks.flatten().tolist()
 
 		##################################################
 		# Blocks
@@ -80,8 +81,9 @@ class qa_find_local_max (gr_unittest.TestCase):
 		# generate vector from octave
 		oc = oct2py.Oct2Py()
 		oc.addpath(os.path.dirname(__file__))
-		data, expected_pks, expected_t_pks = oc.test002_findpeaks(self.num_max_vals, self.vector_len)
+		data, expected_pks, expected_t_pks = oc.test002_findpeaks(self.num_max_vals, self.vector_len, nout=3)
 		data = data.flatten().tolist()
+		expected_pks = expected_pks.flatten().tolist()
 
 		##################################################
 		# Blocks


### PR DESCRIPTION
When calling Octave functions through oct2py, by default only the first output value (`ans`) is returned. To return more than one value, the `nout` optional argument must be set, e.g. `nout=3` for a 3-element tuple.

These changes should allow unit tests to pass.